### PR TITLE
Revamp homepage and chat colors

### DIFF
--- a/EasyHealth/ClientApp/src/App.css
+++ b/EasyHealth/ClientApp/src/App.css
@@ -9,9 +9,9 @@
 html, body, #root, .App {
     height: 100%;
     width: 100%;
-    font-family: 'Arial', sans-serif;
-    background-color: #1e1e1e; /* Dark background for the app */
-    color: #e0e0e0; /* Light text color for contrast */
+    font-family: 'Inter', sans-serif;
+    background-color: #ffffff; /* Light background to match EasyHealth */
+    color: #003459; /* Primary text color */
     overflow-x: hidden;
 }
 

--- a/EasyHealth/ClientApp/src/components/AuthButton.css
+++ b/EasyHealth/ClientApp/src/components/AuthButton.css
@@ -18,7 +18,7 @@
         top: 0;
         width: 100%;
         height: 100%;
-        background-color: #007bff; /* Blue fill */
+        background-color: #3898ec; /* Blue fill */
         z-index: -1; /* Place behind the button text */
         transform: scaleX(0); /* Start invisible */
         transition: transform 0.9s ease;
@@ -29,5 +29,5 @@
     }
 
     .logout-button:hover {
-        border-color: #007bff; /* Border animates from black to blue on hover */
+        border-color: #3898ec; /* Border animates from black to blue on hover */
     }

--- a/EasyHealth/ClientApp/src/components/ChatWindow.css
+++ b/EasyHealth/ClientApp/src/components/ChatWindow.css
@@ -5,11 +5,11 @@
     height: 100%;
     min-height: 80vh;
     width: 100%;
-    background-color: #1e1e1e; /* Dark background for chat window */
-    border: 0.0625em solid #444; /* Darker border */
+    background-color: #fafafa; /* Light background */
+    border: 0.0625em solid #c9d6ee; /* Soft border */
     overflow-y: auto;
     box-sizing: border-box;
-    color: #e0e0e0; /* Light text color for contrast */
+    color: #003459; /* Dark text color */
     border-radius: 0.25em;
     margin-bottom: inherit;
 }
@@ -19,7 +19,7 @@
     overflow-y: auto; /* Enable vertical scrolling */
     scroll-behavior: smooth; /* Smooth scrolling for auto-scroll */
     padding: 0.625em;
-    background-color: #2e2e2e; /* Darker background for message list */
+    background-color: #ffffff; /* Light background for messages */
     max-height: 100%; /* Ensure it doesn't overflow its parent */
 }
 
@@ -41,7 +41,7 @@
 .chat-input {
     display: flex;
     padding: 0.625em;
-    background-color: #2e2e2e; /* Darker background for chat input */
+    background-color: #ffffff; /* Light background for chat input */
     width: 100%;
 }
 
@@ -54,17 +54,17 @@
 
 .chat-input input:focus {
     outline: none;
-    box-shadow: 0 0 10px 2px rgba(0, 123, 255, 0.5); /* Light blue glow */
+    box-shadow: 0 0 10px 2px rgba(56, 152, 236, 0.5); /* Light blue glow */
 }
 
 .chat-input input {
     flex: 1;
     padding: 0.5em;
-    border: 0.0625em solid #444; /* Darker border */
+    border: 0.0625em solid #c9d6ee; /* Soft border */
     border-radius: 0.25em;
     margin-right: 0.3125em;
-    background-color: #3e3e3e; /* Darker input background */
-    color: #e0e0e0; /* Light text color */
+    background-color: #f5f5f5; /* Light input background */
+    color: #003459; /* Dark text color */
 }
 
 .chat-input label {
@@ -73,7 +73,7 @@
     margin-bottom: -.7em;
     z-index: 1;
     font-size: 1rem;
-    color: #e0e0e0; /* Light text color */
+    color: #003459; /* Dark text color */
 }
 
 .toolbar-button {
@@ -81,7 +81,7 @@
     padding: 9px 20px;
     font-size: 16px;
     color: #fff;
-    background-color: #007bff;
+    background-color: #3898ec;
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -89,13 +89,13 @@
 }
 
     .toolbar-button:hover {
-        background-color: #0056b3;
+        background-color: #28a8df;
     }
 
 .chat-input button {
     border: none;
     border-radius: 0.25em;
-    background-color: #007bff;
+    background-color: #3898ec;
     color: white;
     cursor: pointer;
     margin-left: 0.25em;
@@ -103,5 +103,5 @@
 }
 
     .chat-input button:hover {
-        background-color: #0056b3;
+        background-color: #28a8df;
     }

--- a/EasyHealth/ClientApp/src/components/ContentWindow.css
+++ b/EasyHealth/ClientApp/src/components/ContentWindow.css
@@ -4,12 +4,12 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: stretch; /* Ensure children take full width */
-    background-color: #1e1e1e;
+    background-color: #fafafa;
     height: 100%;
     max-height: 75vh;
     width: 100%;
     flex: 1;
-    color: #e0e0e0;
+    color: #003459;
 }
 
 .pane {
@@ -17,30 +17,30 @@
     flex-direction: column;
     justify-content: flex-start; /* Align items to the start */
     align-items: stretch; /* Ensure children take full width */
-    background-color: #1e1e1e; /* Dark background for panes */
+    background-color: #fafafa; /* Light background for panes */
     height: 100%; /* Ensure the pane fills the available vertical space */
     width: 100%; /* Ensure the pane fills the available horizontal space */
     flex: 1; /* Allow the pane to grow and shrink as needed */
-    color: #e0e0e0; /* Light text color for contrast */
+    color: #003459; /* Dark text color */
 }
 
 
 .table-definitions-input {
     width: 100%;
     height: 100%; /* Adjust height to take up as much space as possible, accounting for padding and other elements */
-    border: 1px solid #444; /* Darker border */
+    border: 1px solid #c9d6ee; /* Soft border */
     border-radius: 4px;
     font-size: 14px;
-    font-family: 'Roboto Mono', monospace;
-    background-color: #2e2e2e; /* Darker input background */
-    color: #e0e0e0; /* Light text color */
+    font-family: 'Inter', sans-serif;
+    background-color: #ffffff; /* Light input background */
+    color: #003459; /* Dark text color */
     resize: none;
     padding: 2em;
 }
 
     .table-definitions-input:focus {
         outline: none;
-        box-shadow: 0 0 10px 2px rgba(0, 123, 255, 0.5); /* Light blue glow */
+        box-shadow: 0 0 10px 2px rgba(56, 152, 236, 0.5); /* Light blue glow */
     }
 
 .table-definitions-toolbar {
@@ -59,7 +59,7 @@
     margin-bottom: -.7em;
     z-index: 1;
     font-size: 1rem;
-    color: #e0e0e0; /* Light text color */
+    color: #003459; /* Dark text color */
     text-align: center;
 }
 
@@ -68,14 +68,14 @@
     padding: 9px 20px;
     font-size: 16px;
     color: #fff;
-    background-color: #007bff;
+    background-color: #3898ec;
     border: none;
     border-radius: 4px;
     cursor: pointer;
 }
 
     .toolbar-button:hover {
-        background-color: #0056b3;
+        background-color: #28a8df;
         transition: background-color 0.3s;
     }
 
@@ -98,14 +98,14 @@
 .assistant-input {
     width: 100%;
     padding: 10px 20px;
-    border: 1px solid #444; /* Darker border */
+    border: 1px solid #c9d6ee; /* Soft border */
     border-radius: 4px;
     font-size: 14px;
-    background-color: #2e2e2e; /* Darker input background */
-    color: #e0e0e0; /* Light text color */
+    background-color: #ffffff; /* Light input background */
+    color: #003459; /* Dark text color */
 }
 
     .assistant-input:focus {
         outline: none;
-        box-shadow: 0 0 10px 2px rgba(0, 123, 255, 0.5); /* Light blue glow */
+        box-shadow: 0 0 10px 2px rgba(56, 152, 236, 0.5); /* Light blue glow */
     }

--- a/EasyHealth/ClientApp/src/components/HomePage.css
+++ b/EasyHealth/ClientApp/src/components/HomePage.css
@@ -5,7 +5,7 @@
     align-items: center;
     width: 100%;
     height: 100vh;
-    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Inter', sans-serif;
     margin: 0;
     padding: 0;
     box-sizing: border-box;
@@ -36,7 +36,7 @@
 /* Hero section styling */
 .hero-section {
     width: 100%;
-    background: linear-gradient(135deg, #1d1f21, #2e2e2e);
+    background: linear-gradient(135deg, #003459, #3898ec);
     color: #ffffff;
     padding: 4em 2em;
     text-align: center;
@@ -50,7 +50,7 @@
 .hero-section h1 {
     font-size: 2.5rem;
     margin-bottom: 0.5em;
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Playfair Display', serif;
 }
 
 .hero-section p {
@@ -61,10 +61,10 @@
 
 /* Section title styling */
 .section-title {
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Playfair Display', serif;
     font-size: 2rem;
     font-weight: bold;
-    color: #333333;
+    color: #003459;
     margin-bottom: 0.5em;
     text-align: center;
     text-transform: uppercase;
@@ -73,10 +73,10 @@
 
 /* Section subtitle styling */
 .section-subtitle {
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Inter', sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
-    color: #666666;
+    color: #5d6c7b;
     margin-bottom: 1.5em;
     text-align: center;
     line-height: 1.6;
@@ -84,7 +84,7 @@
 
 /* Contact section links */
 .contact-section a {
-    color: #007bff;
+    color: #3898ec;
     text-decoration: none;
     font-weight: bold;
 }
@@ -95,6 +95,7 @@
 
     .contact-section a:hover {
         text-decoration: underline;
+        color: #28a8df;
     }
 
 .signup-button {
@@ -102,7 +103,7 @@
     display: inline-block;
     padding: 0.25rem 0.5rem;
     color: #ffffff;
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Playfair Display', serif;
     font-weight: bold;
     font-size: 1.25em;
     border: 2px solid #ffffff;
@@ -119,7 +120,7 @@
         top: 0;
         width: 100%;
         height: 100%;
-        background-color: #007bff;
+        background-color: #3898ec;
         z-index: -1;
         transform: scaleX(0);
         transition: transform 0.9s ease;
@@ -130,9 +131,9 @@
     }
 
     .signup-button:hover {
-        border-color: #007bff;
+        border-color: #3898ec;
         /* Add glowing effect */
-        box-shadow: 0 0 8px 2px rgba(0, 123, 255, 0.8);
+        box-shadow: 0 0 8px 2px rgba(56, 152, 236, 0.8);
     }
 
     /* Shimmering effect */
@@ -191,9 +192,9 @@
 
     .pricing-table h2,
     .features h2 {
-        font-family: 'Roboto Mono', monospace;
+        font-family: 'Playfair Display', serif;
         margin-bottom: 1em;
-        color: #333;
+        color: #003459;
     }
 
     /* Pricing table styles */
@@ -212,7 +213,7 @@
     }
 
     .pricing-table th {
-        background-color: #007bff;
+        background-color: #3898ec;
         color: #fff;
     }
 
@@ -235,7 +236,7 @@
             content: "✓";
             position: absolute;
             left: 0;
-            color: #007bff;
+            color: #3898ec;
         }
 
 
@@ -260,10 +261,10 @@
 
     /* Contact section title and subtitle */
     .contact-section h2 {
-        font-family: 'Roboto Mono', monospace;
+        font-family: 'Playfair Display', serif;
         font-size: 2rem;
         font-weight: bold;
-        color: #333333;
+        color: #003459;
         margin-bottom: 0.5em;
         text-align: center;
         text-transform: uppercase;
@@ -277,14 +278,14 @@
     }
 
     .contact-section a {
-        color: #007bff;
+        color: #3898ec;
         text-decoration: none;
         font-weight: bold;
         transition: color 0.3s ease; /* Smooth color transition */
     }
 
         .contact-section a:hover {
-            color: #0056b3; /* Darker blue on hover */
+            color: #28a8df; /* Darker blue on hover */
             text-decoration: underline;
         }
 

--- a/EasyHealth/ClientApp/src/components/Message.css
+++ b/EasyHealth/ClientApp/src/components/Message.css
@@ -1,13 +1,13 @@
-﻿.message-container {
+.message-container {
     max-width: 75%;
     width: fit-content;
-    background-color: #2e2e2e; /* Darker background for message container */
-    color: #e0e0e0; /* Light text color for contrast */
+    background-color: #c9d6ee; /* Light background */
+    color: #003459; /* Dark text color */
 }
 
     .message-container.align-left {
         margin-right: auto;
-        color: #e0e0e0;
+        color: #003459;
     }
 
         .message-container.align-left .message {
@@ -16,7 +16,7 @@
 
     .message-container.align-right {
         margin-left: auto;
-        color: #e0e0e0;
+        color: #003459;
     }
 
     .message-container.align-right .message {
@@ -35,7 +35,7 @@
     white-space: normal;
     max-width: fit-content;
     box-sizing: border-box;
-    background-color: #0f0f0f; /* Dark blue background for messages */
+    background-color: #ffffff; /* Message background */
 }
 
     .message p {

--- a/EasyHealth/ClientApp/src/components/Message.js
+++ b/EasyHealth/ClientApp/src/components/Message.js
@@ -17,7 +17,7 @@ export class Message extends Component {
         const { author, content, alignRight } = this.props;
         const alignmentClass = alignRight ? 'align-left' : 'align-right';
         const messageStyle = {
-            backgroundColor: alignRight ? '#ebebeb' : '#007bff' 
+            backgroundColor: alignRight ? '#ebebeb' : '#3898ec'
         };
 
         return (

--- a/EasyHealth/ClientApp/src/components/NavMenu.css
+++ b/EasyHealth/ClientApp/src/components/NavMenu.css
@@ -1,4 +1,4 @@
-﻿@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@700&display=swap');
 
 .navbar {
     background-color: #f9f8f7;
@@ -6,7 +6,7 @@
     flex-direction: row; /* Align items horizontally */
     justify-content: space-between; /* Ensure space between the brand and nav items */
     align-items: center;
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Inter', sans-serif;
     position: relative;
     width: 100vw; /* Full viewport width */
     padding: 1em 2em;
@@ -43,10 +43,10 @@ a.navbar-brand {
 
 /* Navbar title styling */
 .navbar-title {
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Playfair Display', serif;
     font-size: 2.5rem;
     font-weight: bold;
-    color: #000000;
+    color: #003459;
     text-align: center;
     text-transform: uppercase;
     letter-spacing: 1px;
@@ -57,15 +57,15 @@ a.navbar-brand {
 
     .navbar-title:hover {
         transition: 200ms;
-        color: #007bff;
+        color: #28a8df;
     }
 
 /* Navbar subtitle styling */
 .navbar-subtitle {
-    font-family: 'Roboto Mono', monospace;
+    font-family: 'Inter', sans-serif;
     font-size: 1.2rem;
     font-weight: 400;
-    color: #666666;
+    color: #5d6c7b;
     margin-top: 0.5rem;
     text-align: center;
     letter-spacing: 0.5px;
@@ -116,7 +116,7 @@ a.navbar-brand {
             bottom: -3px; /* Position the underline just below the text */
             width: 0;
             height: 2px;
-            background-color: #007bff;
+            background-color: #3898ec;
             transition: width 0.3s ease; /* Smooth underline animation */
         }
 

--- a/EasyHealth/ClientApp/src/components/WindowWrapper.css
+++ b/EasyHealth/ClientApp/src/components/WindowWrapper.css
@@ -26,8 +26,8 @@
     overflow: auto;
     height: 100%;
     width: 100%; /* Each pane takes up 50% of the width */
-    background-color: #1e1e1e;
-    color: #e0e0e0;
+    background-color: #fafafa;
+    color: #003459;
 }
 
 .chatwindow-label {
@@ -36,7 +36,7 @@
     margin-bottom: -.7em;
     z-index: 1;
     font-size: 2rem;
-    color: #e0e0e0; /* Light text color */
+    color: #003459; /* Text color */
 }
 
 @media (max-width: 1200px) {
@@ -59,8 +59,8 @@
 
 .ReactModal__Content {
     position: relative;
-    background: #2e2e2e;
-    color: #e0e0e0;
+    background: #ffffff;
+    color: #003459;
     border-radius: 4px;
     padding: 2em;
     width: 80%;
@@ -79,7 +79,7 @@
     }
 
     .ReactModal__Content button {
-        background-color: #007bff;
+        background-color: #3898ec;
         color: white;
         border: none;
         padding: 0.5em 1em;
@@ -90,7 +90,7 @@
     }
 
         .ReactModal__Content button:hover {
-            background-color: #0056b3;
+            background-color: #28a8df;
         }
 
         .ReactModal__Content button:last-child {

--- a/EasyHealth/ClientApp/src/index.css
+++ b/EasyHealth/ClientApp/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:wght@700&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
## Summary
- fresh fonts via Google fonts
- update app container styles
- tune homepage gradients and accent colors
- modernize chat interface look
- update navigation bar and modal styles

## Testing
- `npm test --silent --forceExit` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6882e190d200832e94437f4e343e8abd