### PR TITLE
Handle streaming tool calls

### DIFF
--- a/EasyHealth/ClientApp/src/components/ChatWindow.css
+++ b/EasyHealth/ClientApp/src/components/ChatWindow.css
@@ -102,6 +102,13 @@
     margin-right: 0.25em;
 }
 
-    .chat-input button:hover {
-        background-color: #0056b3;
-    }
+.chat-input button:hover {
+    background-color: #0056b3;
+}
+
+.banner-message {
+    background-color: #28a745;
+    color: #fff;
+    padding: 0.5em;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- show success banners for `ScheduleDemo` and `ContactUs` tool calls
- style banner message

## Testing
- `npm test --prefix EasyHealth/ClientApp` *(fails: Jest encountered an unexpected token)*
- `dotnet test EasyHealth.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e72add2c832eb47e3cc8ede7ab3e