### PR TITLE
Handle tool call stream chunks

### DIFF
--- a/EasyHealth/ClientApp/src/components/ChatWindow.css
+++ b/EasyHealth/ClientApp/src/components/ChatWindow.css
@@ -14,6 +14,13 @@
     margin-bottom: inherit;
 }
 
+.banner-message {
+    background-color: #28a745;
+    color: #fff;
+    text-align: center;
+    padding: 0.5em;
+}
+
 .message-list {
     flex: 1;
     overflow-y: auto; /* Enable vertical scrolling */

--- a/EasyHealth/ClientApp/src/components/ChatWindow.js
+++ b/EasyHealth/ClientApp/src/components/ChatWindow.js
@@ -15,6 +15,8 @@ function ChatWindow({ clearMessages }) {
         },
     ]);
     const [connection, setConnection] = useState(null);
+    const [toolBuffers, setToolBuffers] = useState({});
+    const [bannerMessage, setBannerMessage] = useState(null);
     const chatEndRef = useRef(null);
     const profileName = 'easy-health-agent';
 
@@ -28,6 +30,15 @@ function ChatWindow({ clearMessages }) {
             },
             'l4tPGVW0fU2gIrpaI'
         )
+    };
+
+    const handleToolPayload = (toolName, payload) => {
+        if (toolName === 'ContactUs') {
+            setBannerMessage('Success Contact form completed');
+        } else if (toolName === 'ScheduleDemo') {
+            setBannerMessage('Success, Demo Scheduled');
+        }
+        setTimeout(() => setBannerMessage(null), 5000);
     };
 
     useEffect(() => {
@@ -45,6 +56,23 @@ function ChatWindow({ clearMessages }) {
 
                 newConnection.on('broadcastMessage', (chunk) => {
                     console.log('Received chunk:', chunk); // Log the chunk data for debugging
+                    const toolCalls = chunk.toolCalls || chunk.ToolCalls;
+                    if (toolCalls) {
+                        setToolBuffers(prev => {
+                            const updated = { ...prev };
+                            Object.entries(toolCalls).forEach(([name, fragment]) => {
+                                updated[name] = (updated[name] || '') + fragment;
+                                try {
+                                    const payload = JSON.parse(updated[name]);
+                                    handleToolPayload(name, payload);
+                                    delete updated[name];
+                                } catch (e) {
+                                    // incomplete JSON, wait for more chunks
+                                }
+                            });
+                            return updated;
+                        });
+                    }
                     setMessages((prevMessages) => {
                         const lastMessage = prevMessages[prevMessages.length - 1];
                         if (lastMessage && lastMessage.role === 'Assistant') {
@@ -134,6 +162,9 @@ function ChatWindow({ clearMessages }) {
 
     return (
         <div className="chat-window">
+            {bannerMessage && (
+                <div className="banner-message">{bannerMessage}</div>
+            )}
             <div className="message-list">
                 {messages.map((msg, index) => (
                     <Message


### PR DESCRIPTION
## Summary
- capture tool calls from chat stream
- display banner success messages when a tool completes

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e72add2c832eb47e3cc8ede7ab3e