### PR TITLE
Fix banner message with tool name

### DIFF
--- a/EasyHealth/ClientApp/src/components/ChatWindow.js
+++ b/EasyHealth/ClientApp/src/components/ChatWindow.js
@@ -33,11 +33,10 @@ function ChatWindow({ clearMessages }) {
     };
 
     const handleToolPayload = (toolName, payload) => {
-        if (toolName === 'ContactUs') {
-            setBannerMessage('Success Contact form completed');
-        } else if (toolName === 'ScheduleDemo') {
-            setBannerMessage('Success, Demo Scheduled');
-        }
+        // Display which tool was executed so users know what happened
+        setBannerMessage(`Success: ${toolName}`);
+
+        // Clear the banner after a short period
         setTimeout(() => setBannerMessage(null), 5000);
     };
 


### PR DESCRIPTION
## Summary
- show which tool executed in the banner message after a tool call

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6882ec1dc30c832e8b275aa2c52479f6